### PR TITLE
Pass options through to Rails' routing DSL

### DIFF
--- a/lib/api-versions.rb
+++ b/lib/api-versions.rb
@@ -11,7 +11,7 @@ module ApiVersions
     VersionCheck.default_version = options[:default_version]
     VersionCheck.vendor_string   = options[:vendor_string]
 
-    namespace(:api) { DSL.new(self, &block) }
+    namespace(:api, options) { DSL.new(self, &block) }
   end
 end
 

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -18,6 +18,14 @@ Dummy::Application.routes.draw do
     end
   end
 
+  api vendor_string: 'myvendor', path: '' do
+    version 1 do
+      cache as: 'v1' do
+        resources :baz
+      end
+    end
+  end
+
   get '*a' => 'errors#not_found'
 
   get 'index' => 'simplified_format#index'

--- a/spec/routing_spec.rb
+++ b/spec/routing_spec.rb
@@ -119,4 +119,10 @@ describe 'API Routing' do
       response.status.should == 404
     end
   end
+
+  describe 'paths' do
+    it "should pass options, such as :path, to the regular routing DSL" do
+      new_api_baz_path.should == '/baz/new'
+    end
+  end
 end


### PR DESCRIPTION
It would be nice to use the same options that Rails allows for, say,
namespacing an API. I use a subdomain for my API, which makes `/api` in
my path a redundancy. Instead of throwing away options that aren't
`:vendor_string`, pass them through to Rails.

Signed-off-by: David Celis me@davidcel.is
