### PR TITLE
Remove rubyforge link from gemspec

### DIFF
--- a/api-versions.gemspec
+++ b/api-versions.gemspec
@@ -11,8 +11,6 @@ Gem::Specification.new do |s|
   s.summary     = "api-versions helps manage your Rails app API endpoints."
   s.description = "api-versions helps manage your Rails app API endpoints."
 
-  s.rubyforge_project = "api-versions"
-
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }


### PR DESCRIPTION
Rubyforge is sunsetted, see: https://twitter.com/evanphx/status/399552820380053505